### PR TITLE
README: Fix package name of json-glib-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fedora (35)だと
 * vala
 * meson
 * libgee-devel
-* libjson-glib-devel
+* json-glib-devel
 
 Ubuntu (20.04)だと
 


### PR DESCRIPTION
Thanks for making really a nice app!

Tiny thing but there are no package named `libjson-glib-devel`, instead it called `json-glib-devel`:

https://packages.fedoraproject.org/pkgs/json-glib/json-glib-devel/
